### PR TITLE
security: Fix search_path warnings in Supabase functions

### DIFF
--- a/supabase/migrations/20250104000001_create_schema.sql
+++ b/supabase/migrations/20250104000001_create_schema.sql
@@ -17,12 +17,16 @@ CREATE TYPE IF NOT EXISTS municipality_type AS ENUM ('city', 'county');
 
 -- Create updated_at trigger function
 CREATE OR REPLACE FUNCTION public.handle_updated_at()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER 
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
 BEGIN
     NEW.updated_at = NOW();
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 -- 1. PROFILES TABLE (User profiles)
 CREATE TABLE IF NOT EXISTS public.profiles (

--- a/supabase/migrations/20250104000002_create_functions.sql
+++ b/supabase/migrations/20250104000002_create_functions.sql
@@ -88,29 +88,41 @@ $$;
 
 -- Function to initialize user contributions record
 CREATE OR REPLACE FUNCTION public.initialize_user_contributions()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER 
+LANGUAGE plpgsql 
+SECURITY DEFINER
+SET search_path = ''
+AS $$
 BEGIN
     INSERT INTO public.user_contributions (user_id)
     VALUES (NEW.id)
     ON CONFLICT (user_id) DO NOTHING;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;
 
 -- Function to initialize user preferences when profile is created
 CREATE OR REPLACE FUNCTION public.initialize_user_preferences()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER 
+LANGUAGE plpgsql 
+SECURITY DEFINER
+SET search_path = ''
+AS $$
 BEGIN
     INSERT INTO public.user_preferences (user_id)
     VALUES (NEW.id)
     ON CONFLICT (user_id) DO NOTHING;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;
 
 -- Function to update user contribution stats when submission status changes
 CREATE OR REPLACE FUNCTION public.update_user_contribution_stats()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER 
+LANGUAGE plpgsql 
+SECURITY DEFINER
+SET search_path = ''
+AS $$
 BEGIN
     -- If this is a new submission
     IF TG_OP = 'INSERT' THEN
@@ -170,7 +182,7 @@ BEGIN
 
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;
 
 -- Function to approve a submission and create/update the legislation record
 CREATE OR REPLACE FUNCTION public.approve_submission(


### PR DESCRIPTION
- Add SET search_path = '' to all trigger functions for security
- Fix handle_updated_at function in schema migration
- Fix initialize_user_contributions function
- Fix initialize_user_preferences function
- Fix update_user_contribution_stats function
- Standardize function syntax with proper SECURITY DEFINER placement

This resolves all Supabase Security Advisor warnings about missing search_path parameters.