### PR TITLE
fix: Add missing 'Repealed' option to legislation type dropdowns

### DIFF
--- a/src/components/DataFilters.tsx
+++ b/src/components/DataFilters.tsx
@@ -166,6 +166,7 @@ const DataFilters = ({ onFilterChange, breedLegislationData }: DataFiltersProps)
               <SelectItem value="all">All types</SelectItem>
               <SelectItem value="ban">Ban</SelectItem>
               <SelectItem value="restriction">Restriction</SelectItem>
+              <SelectItem value="repealed">Repealed</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/components/submissions/SubmissionEditForm.tsx
+++ b/src/components/submissions/SubmissionEditForm.tsx
@@ -215,7 +215,7 @@ const SubmissionEditForm: React.FC<SubmissionEditFormProps> = ({
             <Label htmlFor="legislation_type">Legislation Type</Label>
             <Select 
               value={formData.legislation_type || 'ban'} 
-              onValueChange={(value) => setFormData(prev => ({ ...prev, legislation_type: value as 'ban' | 'restriction' }))}
+              onValueChange={(value) => setFormData(prev => ({ ...prev, legislation_type: value as 'ban' | 'restriction' | 'repealed' }))}
             >
               <SelectTrigger>
                 <SelectValue />
@@ -223,6 +223,7 @@ const SubmissionEditForm: React.FC<SubmissionEditFormProps> = ({
               <SelectContent>
                 <SelectItem value="ban">Ban</SelectItem>
                 <SelectItem value="restriction">Restriction</SelectItem>
+                <SelectItem value="repealed">Repealed</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/components/submissions/form-components/LegislationForm.tsx
+++ b/src/components/submissions/form-components/LegislationForm.tsx
@@ -163,6 +163,14 @@ const LegislationForm: React.FC<LegislationFormProps> = ({
                     </div>
                   </div>
                 </SelectItem>
+                <SelectItem value="repealed">
+                  <div>
+                    <div className="font-medium">Repealed</div>
+                    <div className="text-sm text-muted-foreground">
+                      Previously enacted legislation that has been repealed
+                    </div>
+                  </div>
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>


### PR DESCRIPTION
Fixes #3 - The 'Repealed' legislation type was missing from dropdown filters and forms

Changes:
- Add 'Repealed' option to main DataFilters legislation type dropdown
- Add 'Repealed' option to SubmissionEditForm legislation type selector
- Add 'Repealed' option to LegislationForm with descriptive text
- Update TypeScript types to include 'repealed' in form handlers

Users can now filter by and select 'Repealed' legislation type across all forms and filters.