### PR TITLE
fix: Resolve blank screen in submission wizard step navigation

### DIFF
--- a/src/components/submissions/steps/LegislationDetailsStep.tsx
+++ b/src/components/submissions/steps/LegislationDetailsStep.tsx
@@ -12,6 +12,8 @@ interface LegislationDetailsStepProps {
   onDataChange: (data: Partial<SubmissionFormData>) => void;
   onNext: () => void;
   onPrevious: () => void;
+  onSubmit?: (data: SubmissionFormData) => void;
+  isSubmitting?: boolean;
 }
 
 const LegislationDetailsStep: React.FC<LegislationDetailsStepProps> = ({

--- a/src/components/submissions/steps/LocationStep.tsx
+++ b/src/components/submissions/steps/LocationStep.tsx
@@ -10,6 +10,8 @@ interface LocationStepProps {
   onDataChange: (data: Partial<SubmissionFormData>) => void;
   onNext: () => void;
   onPrevious: () => void;
+  onSubmit?: (data: SubmissionFormData) => void;
+  isSubmitting?: boolean;
 }
 
 const LocationStep: React.FC<LocationStepProps> = ({

--- a/src/components/submissions/steps/ReviewSubmitStep.tsx
+++ b/src/components/submissions/steps/ReviewSubmitStep.tsx
@@ -21,6 +21,8 @@ import DuplicateWarning from '../DuplicateWarning';
 
 interface ReviewSubmitStepProps {
   data: Partial<SubmissionFormData>;
+  onDataChange?: (data: Partial<SubmissionFormData>) => void;
+  onNext?: () => void;
   onPrevious: () => void;
   onSubmit: (data: SubmissionFormData) => void;
   isSubmitting: boolean;

--- a/src/components/submissions/steps/SourcesDocumentsStep.tsx
+++ b/src/components/submissions/steps/SourcesDocumentsStep.tsx
@@ -19,6 +19,8 @@ interface SourcesDocumentsStepProps {
   onDataChange: (data: Partial<SubmissionFormData>) => void;
   onNext: () => void;
   onPrevious: () => void;
+  onSubmit?: (data: SubmissionFormData) => void;
+  isSubmitting?: boolean;
 }
 
 // Remove the old UploadedFile interface as we're using DocumentMetadata now

--- a/src/components/submissions/steps/SubmissionTypeStep.tsx
+++ b/src/components/submissions/steps/SubmissionTypeStep.tsx
@@ -10,6 +10,9 @@ interface SubmissionTypeStepProps {
   data: Partial<SubmissionFormData>;
   onDataChange: (data: Partial<SubmissionFormData>) => void;
   onNext: () => void;
+  onPrevious?: () => void;
+  onSubmit?: (data: SubmissionFormData) => void;
+  isSubmitting?: boolean;
 }
 
 const SubmissionTypeStep: React.FC<SubmissionTypeStepProps> = ({


### PR DESCRIPTION
Fix prop interface mismatch between SubmissionWizard and step components that was causing blank screens when navigating between steps.

Changes:
- Standardize all step component interfaces to accept the same props
- Add optional onSubmit and isSubmitting props to non-final steps
- Add optional onDataChange and onNext props to ReviewSubmitStep
- Ensure all steps can receive the same props from SubmissionWizard

This resolves the blank screen issue when clicking 'Next' after entering legislation details.