### PR TITLE
Fix duplicate navigation buttons in SubmissionWizard

### DIFF
--- a/src/components/submissions/SubmissionWizard.tsx
+++ b/src/components/submissions/SubmissionWizard.tsx
@@ -61,12 +61,37 @@ const SubmissionWizard: React.FC<SubmissionWizardProps> = ({ onComplete, onCance
   };
 
   const canGoNext = () => {
-    // Add validation logic here based on current step
-    return true; // Placeholder
+    switch (currentStep) {
+      case 1: // Submission Type
+        return !!formData.type;
+      case 2: // Location
+        return !!(formData.municipality?.trim() && formData.state);
+      case 3: // Legislation Details
+        return !!(formData.ordinance?.trim() && formData.banned_breeds && formData.banned_breeds.length > 0);
+      case 4: // Sources & Documents
+        return true; // This step is optional
+      case 5: // Review & Submit
+        return false; // This step uses its own submit logic
+      default:
+        return false;
+    }
   };
 
   const canGoPrevious = () => {
     return currentStep > 1;
+  };
+
+  const isFormComplete = () => {
+    return !!(
+      formData.type &&
+      formData.municipality &&
+      formData.state &&
+      formData.municipality_type &&
+      formData.ordinance &&
+      formData.legislation_type &&
+      formData.banned_breeds &&
+      formData.banned_breeds.length > 0
+    );
   };
 
   if (!currentStepData) {
@@ -164,8 +189,18 @@ const SubmissionWizard: React.FC<SubmissionWizardProps> = ({ onComplete, onCance
                   onClick={handleNext}
                   disabled={!canGoNext() || isSubmitting}
                 >
-                  Next
+                  {currentStep === 4 ? 'Review & Submit' : 'Next'}
                   <ChevronRight className="w-4 h-4 ml-2" />
+                </Button>
+              )}
+              
+              {currentStep === STEPS.length && (
+                <Button
+                  onClick={() => handleSubmit(formData as SubmissionFormData)}
+                  disabled={!formData._reviewStepValid || isSubmitting}
+                  className="min-w-[120px]"
+                >
+                  {isSubmitting ? 'Submitting...' : 'Submit for Review'}
                 </Button>
               )}
             </div>

--- a/src/components/submissions/steps/LegislationDetailsStep.tsx
+++ b/src/components/submissions/steps/LegislationDetailsStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertCircle, Info, Loader2 } from 'lucide-react';
@@ -36,7 +36,8 @@ const LegislationDetailsStep: React.FC<LegislationDetailsStepProps> = ({
     debounceMs: 2000 // Longer debounce for this step
   });
 
-  const validateForm = () => {
+  // Validate form and update errors for display
+  React.useEffect(() => {
     const newErrors: string[] = [];
     
     if (!data.ordinance?.trim()) {
@@ -48,14 +49,7 @@ const LegislationDetailsStep: React.FC<LegislationDetailsStepProps> = ({
     }
     
     setErrors(newErrors);
-    return newErrors.length === 0;
-  };
-
-  const handleNext = () => {
-    if (validateForm()) {
-      onNext();
-    }
-  };
+  }, [data.ordinance, data.banned_breeds]);
 
   return (
     <div className="space-y-6">
@@ -109,14 +103,6 @@ const LegislationDetailsStep: React.FC<LegislationDetailsStepProps> = ({
         </Alert>
       )}
 
-      <div className="flex justify-between">
-        <Button variant="outline" onClick={onPrevious}>
-          Previous
-        </Button>
-        <Button onClick={handleNext}>
-          Next: Sources & Documents
-        </Button>
-      </div>
     </div>
   );
 };

--- a/src/components/submissions/steps/LocationStep.tsx
+++ b/src/components/submissions/steps/LocationStep.tsx
@@ -22,7 +22,8 @@ const LocationStep: React.FC<LocationStepProps> = ({
 }) => {
   const [errors, setErrors] = useState<string[]>([]);
 
-  const validateForm = () => {
+  // Validate form and update errors for display
+  useEffect(() => {
     const newErrors: string[] = [];
     
     if (!data.municipality?.trim()) {
@@ -34,14 +35,7 @@ const LocationStep: React.FC<LocationStepProps> = ({
     }
     
     setErrors(newErrors);
-    return newErrors.length === 0;
-  };
-
-  const handleNext = () => {
-    if (validateForm()) {
-      onNext();
-    }
-  };
+  }, [data.municipality, data.state]);
 
   return (
     <div className="space-y-6">
@@ -83,15 +77,6 @@ const LocationStep: React.FC<LocationStepProps> = ({
           <li>• For counties, include "County" in the name (e.g., "Los Angeles County")</li>
           <li>• For cities, use the full official name</li>
         </ul>
-      </div>
-
-      <div className="flex justify-between">
-        <Button variant="outline" onClick={onPrevious}>
-          Previous
-        </Button>
-        <Button onClick={handleNext}>
-          Next: Legislation Details
-        </Button>
       </div>
     </div>
   );

--- a/src/components/submissions/steps/ReviewSubmitStep.tsx
+++ b/src/components/submissions/steps/ReviewSubmitStep.tsx
@@ -47,15 +47,7 @@ const ReviewSubmitStep: React.FC<ReviewSubmitStepProps> = ({
     enabled: isFormComplete()
   });
 
-  const handleSubmit = () => {
-    if (!agreedToTerms) return;
-    if (hasDuplicates && !duplicateWarningAcknowledged) return;
-    
-    // Validate that we have all required data
-    if (isFormComplete()) {
-      onSubmit(data as SubmissionFormData);
-    }
-  };
+
 
   const isFormComplete = () => {
     return !!(
@@ -79,6 +71,15 @@ const ReviewSubmitStep: React.FC<ReviewSubmitStepProps> = ({
       !isChecking
     );
   };
+
+  // Notify parent about validation state changes
+  React.useEffect(() => {
+    if (onDataChange) {
+      onDataChange({
+        _reviewStepValid: canSubmit()
+      });
+    }
+  }, [agreedToTerms, duplicateWarningAcknowledged, hasDuplicates, isSubmitting, isChecking, onDataChange]);
 
   return (
     <div className="space-y-6">
@@ -292,20 +293,6 @@ const ReviewSubmitStep: React.FC<ReviewSubmitStepProps> = ({
         </ol>
       </div>
 
-      {/* Action Buttons */}
-      <div className="flex justify-between">
-        <Button variant="outline" onClick={onPrevious} disabled={isSubmitting}>
-          Previous
-        </Button>
-        
-        <Button 
-          onClick={handleSubmit} 
-          disabled={!canSubmit()}
-          className="min-w-[120px]"
-        >
-          {isSubmitting ? 'Submitting...' : 'Submit for Review'}
-        </Button>
-      </div>
     </div>
   );
 };

--- a/src/components/submissions/steps/SourcesDocumentsStep.tsx
+++ b/src/components/submissions/steps/SourcesDocumentsStep.tsx
@@ -47,7 +47,8 @@ const SourcesDocumentsStep: React.FC<SourcesDocumentsStepProps> = ({
     });
   }, [ordinanceUrl, verificationDate, onDataChange]);
 
-  const validateForm = () => {
+  // Validate form and update errors/warnings for display
+  useEffect(() => {
     const newErrors: string[] = [];
     const newWarnings: string[] = [];
     
@@ -67,14 +68,7 @@ const SourcesDocumentsStep: React.FC<SourcesDocumentsStepProps> = ({
     
     setErrors(newErrors);
     setWarnings(newWarnings);
-    return newErrors.length === 0;
-  };
-
-  const handleNext = () => {
-    if (validateForm()) {
-      onNext();
-    }
-  };
+  }, [ordinanceUrl, documents]);
 
   const handleDocumentsChange = (newDocuments: DocumentMetadata[]) => {
     setDocuments(newDocuments);
@@ -197,14 +191,6 @@ const SourcesDocumentsStep: React.FC<SourcesDocumentsStepProps> = ({
         </ul>
       </div>
 
-      <div className="flex justify-between">
-        <Button variant="outline" onClick={onPrevious}>
-          Previous
-        </Button>
-        <Button onClick={handleNext}>
-          Next: Review & Submit
-        </Button>
-      </div>
     </div>
   );
 };

--- a/src/components/submissions/steps/SubmissionTypeStep.tsx
+++ b/src/components/submissions/steps/SubmissionTypeStep.tsx
@@ -24,11 +24,7 @@ const SubmissionTypeStep: React.FC<SubmissionTypeStepProps> = ({
     onDataChange({ type });
   };
 
-  const handleNext = () => {
-    if (data.type) {
-      onNext();
-    }
-  };
+
 
   return (
     <div className="space-y-6">
@@ -104,13 +100,7 @@ const SubmissionTypeStep: React.FC<SubmissionTypeStepProps> = ({
         </Card>
       </RadioGroup>
 
-      {data.type && (
-        <div className="flex justify-center">
-          <Button onClick={handleNext} size="lg">
-            Continue with {data.type === 'new_legislation' ? 'New Legislation' : 'Update'}
-          </Button>
-        </div>
-      )}
+
     </div>
   );
 };

--- a/src/types/submissions.ts
+++ b/src/types/submissions.ts
@@ -93,9 +93,8 @@ export interface SubmissionFormData {
   municipality_type: 'City' | 'County';
 
   // Step 3: Legislation details
-  ordinance_title: string;
+  ordinance: string;
   banned_breeds: string[];
-  ordinance_text: string;
   legislation_type: LegislationType;
   population?: number;
   coordinates?: {
@@ -106,11 +105,20 @@ export interface SubmissionFormData {
   // Step 4: Sources and documents
   ordinance_url?: string;
   additional_sources?: string[];
-  documents?: File[];
+  documents?: Array<{
+    id: string;
+    fileName: string;
+    fileUrl: string;
+    fileType: string;
+    fileSize: number;
+  }>;
   verification_date?: string;
 
   // Step 5: Review
-  terms_accepted: boolean;
+  terms_accepted?: boolean;
+  
+  // Internal validation state
+  _reviewStepValid?: boolean;
 }
 
 export interface DuplicateCheckResult {


### PR DESCRIPTION
- Remove navigation buttons from all step components
- Centralize navigation control in SubmissionWizard
- Add proper step validation logic to canGoNext()
- Update SubmissionFormData type to match component usage
- Add _reviewStepValid property for final step validation
- Maintain real-time validation display in step components

This resolves the UX confusion from duplicate Next/Previous buttons and should fix the blank screen submission issue.